### PR TITLE
hadcode timezone formatting to use Europe/Helsinki

### DIFF
--- a/src/util/date.ts
+++ b/src/util/date.ts
@@ -7,6 +7,7 @@ export const formatDate = (timestamp: string) => {
     month: 'numeric',
     day: 'numeric',
     hour: 'numeric',
-    minute: 'numeric'
+    minute: 'numeric',
+    timeZone: 'Europe/Helsinki'
   }).format(new Date(timestamp))
 }


### PR DESCRIPTION
All our timestamps are in UTC+0 which looks incorrect while they're technically correct. This hides that particular ambiguity.