### PR TITLE
use ISO-8601 compatible timestamp for logging to allow better analysis…

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,14 +1,32 @@
-server {
-       listen 5173;
-       server_name localhost;
-       root   /var/www/html/;
-       location /ui {
-          index  index.html;
-          try_files $uri $uri/ /index.html;
-       }
-       # Without this, page refreshing ends up with error 404:
-       location / {
-            root   /var/www/html/ui;
-       }
+# timestamp fiddling to make it match ISO8601 with milliseconds, without separating T as is used in other services
+# within TIS
+map "$time_iso8601" $iso8601_date {
+    ~([^T]+) $1;
 }
+map "$time_iso8601" $iso8601_time {
+    ~T([0-9:]+)\+ $1;
+}
+map "$msec" $millisec {
+    ~\.([0-9]+)$ $1;
+}
+log_format cloudwatch '$iso8601_date $iso8601_time,$millisec $remote_addr - $remote_user '
+                      '"$request" $status $body_bytes_sent '
+                      '"$http_referer" "$http_user_agent"';
+access_log   /var/log/nginx/access.log  cloudwatch;
+server {
+    listen 5173;
+    server_name localhsot;
+    access_log /var/log/nginx/access.log cloudwatch;
 
+    root /var/www/html/;
+
+    location /ui {
+        index   index.html;
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Without this, page refreshing ends up with error 404:
+    location / {
+        root    /var/www/html/ui;
+    }
+}


### PR DESCRIPTION
…of logs in CloudWatch/ELK