### PR TITLE
TIS-588/remove version identifiers from translation strings

### DIFF
--- a/src/locales/en/translation.ts
+++ b/src/locales/en/translation.ts
@@ -97,8 +97,11 @@ export const en = {
         rules: {
           'gtfs.canonical.v4_1_0': 'Canonical GTFS Validator by MobilityData, version v4.1.0',
           'gtfs.canonical.v4_0_0': 'Canonical GTFS Validator by MobilityData, version v4.0.0',
+          'gtfs.canonical': 'Canonical GTFS Validator by MobilityData',
           'netex.entur.v1_0_1': 'NeTEx Validator by Entur, version v1.0.1',
-          'gtfs2netex.fintraffic.v1_0_0': 'GTFS to NeTEx Converter by Fintraffic, version v1.12.0'
+          'netex.entur': 'NeTEx Validator by Entur',
+          'gtfs2netex.fintraffic.v1_0_0': 'GTFS to NeTEx Converter by Fintraffic, version v1.12.0',
+          'gtfs2netex.fintraffic': 'GTFS to NeTEx Converter by Fintraffic'
         },
         noValidationRulesFound: 'No validation rules found for the chosen company and data format',
         netex: {

--- a/src/locales/fi/translation.ts
+++ b/src/locales/fi/translation.ts
@@ -93,8 +93,11 @@ export const fi = {
         rules: {
           'gtfs.canonical.v4_1_0': 'Canonical GTFS Validator by MobilityData, versio v4.1.0',
           'gtfs.canonical.v4_0_0': 'Canonical GTFS Validator by MobilityData, versio v4.0.0',
+          'gtfs.canonical': 'Canonical GTFS Validator by MobilityData',
           'netex.entur.v1_0_1': 'NeTEx Validator by Entur, versio v1.0.1',
-          'gtfs2netex.fintraffic.v1_0_0': 'GTFS to NeTEx Converter by Fintraffic, versio v1.12.0'
+          'netex.entur': 'NeTEx Validator by Entur',
+          'gtfs2netex.fintraffic.v1_0_0': 'GTFS to NeTEx Converter by Fintraffic, versio v1.12.0',
+          'gtfs2netex.fintraffic': 'GTFS to NeTEx Converter by Fintraffic'
         },
         noValidationRulesFound: 'Validointisääntöjä ei löytynyt',
         netex: {

--- a/src/locales/sv/translation.ts
+++ b/src/locales/sv/translation.ts
@@ -93,8 +93,11 @@ export const sv = {
         rules: {
           'gtfs.canonical.v4_1_0': 'Canonical GTFS Validator by MobilityData, version v4.1.0',
           'gtfs.canonical.v4_0_0': 'Canonical GTFS Validator by MobilityData, version v4.0.0',
+          'gtfs.canonical': 'Canonical GTFS Validator by MobilityData',
           'netex.entur.v1_0_1': 'NeTEx Validator by Entur, version v1.0.1',
-          'gtfs2netex.fintraffic.v1_0_0': 'GTFS to NeTEx Converter by Fintraffic, version v1.12.0'
+          'netex.entur': 'NeTEx Validator by Entur',
+          'gtfs2netex.fintraffic.v1_0_0': 'GTFS to NeTEx Converter by Fintraffic, version v1.12.0',
+          'gtfs2netex.fintraffic': 'GTFS to NeTEx Converter by Fintraffic'
         },
         noValidationRulesFound: 'Inga valideringsregler hittades',
         netex: {


### PR DESCRIPTION
Old identifiers are kept for compatability's sake.