### PR TITLE
TIS-642/use data delivery query logic for populating weekly emails

### DIFF
--- a/src/components/DataDelivery/DataDeliveryView.tsx
+++ b/src/components/DataDelivery/DataDeliveryView.tsx
@@ -29,7 +29,7 @@ const DataDeliveryView = ({ data }: DataDeliveryProps) => {
     if (bootstrap && data) {
       const rows: TableItem[][] = data.map((latestCompanyEntry: CompanyLatestEntryResource) => {
         const row: TableItem[] = getTableRow(latestCompanyEntry, t)
-        const finalRow: TableItem[] = row.slice(0, 6)
+        const finalRow: TableItem[] = row.slice(0, 7)
         // insert status related column value just between submission date and link to the entry page:
         if (latestCompanyEntry.data.status && latestCompanyEntry.data.publicId) {
           finalRow.push({

--- a/src/components/DataDelivery/helpers.ts
+++ b/src/components/DataDelivery/helpers.ts
@@ -19,6 +19,11 @@ export const getTableHeaders = (t: TFunction<'translation', undefined>): HeaderI
       colSpan: 1
     },
     {
+      name: 'context',
+      value: t('admin:dataDelivery:table:context'),
+      colSpan: 1
+    },
+    {
       name: 'url',
       value: t('admin:dataDelivery:table:url'),
       colSpan: 3
@@ -72,6 +77,12 @@ export const getTableRow = (
       value: getBusinessId(companyLatestEntryResource.data.businessId),
       colSpan: 1,
       plainValue: companyLatestEntryResource.data.businessId
+    },
+    {
+      name: 'context',
+      value: companyLatestEntryResource.data.context ? companyLatestEntryResource.data.context : '',
+      colSpan: 1,
+      plainValue: companyLatestEntryResource.data.context
     },
     {
       name: 'url',

--- a/src/locales/en/translation.ts
+++ b/src/locales/en/translation.ts
@@ -319,7 +319,8 @@ export const en = {
         status: 'Status',
         report: 'Latest submission',
         reportLink: 'View submission',
-        url: 'URL'
+        url: 'URL',
+        context: 'Context identifier'
       }
     },
     companies: {

--- a/src/locales/fi/translation.ts
+++ b/src/locales/fi/translation.ts
@@ -321,7 +321,8 @@ export const fi = {
         status: 'Tila',
         report: 'Viimeisin julkaisu',
         reportLink: 'Näytä julkaisu',
-        url: 'URL'
+        url: 'URL',
+        context: 'Kontekstitunniste'
       }
     },
     companies: {

--- a/src/locales/sv/translation.ts
+++ b/src/locales/sv/translation.ts
@@ -320,7 +320,8 @@ export const sv = {
         status: 'Status',
         report: 'Senast publikationen',
         reportLink: 'Visa publikation',
-        url: 'URL'
+        url: 'URL',
+        context: 'Kontextidentifiare'
       }
     },
     companies: {

--- a/src/types/DataDelivery.ts
+++ b/src/types/DataDelivery.ts
@@ -10,6 +10,7 @@ export interface CompanyLatestEntry {
   businessId: string
   // All the fields below can be null if the Company has no entries at all
   publicId: string | null
+  context: string | null
   url: string | null
   format: string | null
   convertedFormat: string | null


### PR DESCRIPTION
also adds context identifier to data delivery view to make it unambigous how the grouping really works now

also fixes TIS-644